### PR TITLE
Add Ability to Paste in CT URL

### DIFF
--- a/column-ios/ContentView.swift
+++ b/column-ios/ContentView.swift
@@ -1,14 +1,24 @@
 import SwiftUI
 
-let url = "<put user url from backend here>"
+let defaultUserUrl = "<user url>"
 
 struct ContentView: View {
+    @State private var inputText: String = ""
     @State var activeWebView = false
 
     var body: some View {
         ZStack {
             Color(UIColor(red: 0.00, green: 0.00, blue: 0.00, alpha: 1.0)).edgesIgnoringSafeArea(.all)
-            VStack(alignment: .center, spacing: 0) {
+            VStack(alignment: .center, spacing: 20) {
+                Text("CT iOS Tester")
+                    .foregroundColor(.white)
+                    .font(.title)
+
+                // Single-line text input
+                TextField("Paste Column Tax URL here", text: $inputText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+
                 Button(action: {
                     self.activeWebView = true
                 }) {
@@ -19,11 +29,19 @@ struct ContentView: View {
                         .border(Color(.white), width: 5)
                 }.sheet(isPresented: $activeWebView, content: {
                     ColumnModuleView(
-                        urlRequest: URLRequest(url: URL(string: url)!),
+                        urlRequest: URLRequest(url: URL(string: getUrlText())!),
                         isPresented: self.$activeWebView,
                         moduleEventController: ColumnMessageHandler(eventHandler: self.eventHandler)).edgesIgnoringSafeArea(.all)
                 })
             }
+        }
+    }
+
+    func getUrlText() -> String {
+        if (self.inputText.isEmpty) {
+            return defaultUserUrl;
+        } else {
+            return self.inputText;
         }
     }
 


### PR DESCRIPTION
Usability improvement to enter the sample app via a pasted URL

See:

<img width="347" alt="image" src="https://github.com/column-tax/column-ios-sample/assets/12505097/099c07c7-f8c9-4cce-8768-f5a7d984a92b">
